### PR TITLE
Dnsdock

### DIFF
--- a/cu-platform/docker-compose.yml
+++ b/cu-platform/docker-compose.yml
@@ -58,7 +58,7 @@ testmysqldata:
         - /etc/timezone:/etc/timezone:ro
 
 dnsdock:
-    image: tonistiigi/dnsdock
+    image: tonistiigi/dnsdock:v1.10.0
     volumes:
         - /var/run/docker.sock:/var/run/docker.sock
         - /etc/localtime:/etc/localtime:ro

--- a/cu-platform/docker-compose.yml
+++ b/cu-platform/docker-compose.yml
@@ -57,22 +57,15 @@ testmysqldata:
         - /etc/localtime:/etc/localtime:ro
         - /etc/timezone:/etc/timezone:ro
 
-skydock:
-    image: ubergarm/skyservices:no-expire
-    command: /bin/sh -c "sleep 3 ; /go/bin/skydock -environment cloud -s /docker.sock -domain unit -name cuplatform_skydns_1"
+dnsdock:
+    image: tonistiigi/dnsdock
     volumes:
-        - /var/run/docker.sock:/docker.sock 
+        - /var/run/docker.sock:/var/run/docker.sock
         - /etc/localtime:/etc/localtime:ro
         - /etc/timezone:/etc/timezone:ro
-
-skydns:
-    image: ubergarm/skyservices:no-expire
-    ports: 
-        - "172.17.42.1:53:53/udp"
-    command: /go/bin/skydns -http 0.0.0.0:8080 -dns 0.0.0.0:53 -nameserver 8.8.8.8:53 -domain unit
-    volumes:
-        - /etc/localtime:/etc/localtime:ro
-        - /etc/timezone:/etc/timezone:ro
+    ports:
+       - "172.17.42.1:53:53/udp"
+    command: -nameserver="8.8.8.8:53" -http=":80" -dns=":53" -verbose="true" -environment="cloud" -domain="unit"
 
 tomcat:
     image: tomcat:7-jre8
@@ -81,7 +74,7 @@ tomcat:
         - /etc/localtime:/etc/localtime:ro
         - /etc/timezone:/etc/timezone:ro 
         - /var/log/cloudunit/tomcat/culogin.log:/var/log/culogin.log
-#TO_UNCOMMENT_IF_CU_KVM_TRUE        - /dev/urandom:/dev/random
+        - /dev/urandom:/dev/random
     environment:
         - CU_SUB_DOMAIN
         - CU_KVM

--- a/cu-platform/start-platform.sh
+++ b/cu-platform/start-platform.sh
@@ -17,7 +17,7 @@
 export FROM_RESET=$1
 
 LOCK=/tmp/start-platform.lock
-SKYDNS_CMD="dig unit @172.17.42.1 +short | wc -l"
+SKYDNS_CMD="dig cloud.unit @172.17.42.1 +short | wc -l"
 
 export CU_SUB_DOMAIN=.$(hostname)
 
@@ -37,7 +37,7 @@ else
 		echo -n -e "\nERREUR: RENSEIGNEZ PROFILE=dev/prod DANS .profile !!\n"
 	fi
 
-	docker-compose up -d skydns
+	docker-compose up -d dnsdock
 
 	# Attente du démarrage de skydns
 	echo "Skydns test"
@@ -48,7 +48,6 @@ else
 		sleep 1
 	done
 
-	docker-compose up -d skydock
 	docker-compose up -d mysqldata
 	docker-compose up -d mysql
 

--- a/documentation/DEMO-GUIDE.md
+++ b/documentation/DEMO-GUIDE.md
@@ -55,6 +55,20 @@ CloudUnit WebUI is available at the box IP. You can login with the credentials j
 
 URL entrypoint is [https://demo.cloudunit.io](https://demo.cloudunit.io)
 
+You should get an "Insecure connection" warning. This is expected as we don't provide you with our certificates for the cloudunit.io domain!
+
 ![login](https://github.com/Treeptik/CloudUnit-images/blob/master/CU-login.png)
 
+
+## Reset CloudUnit
+If you want to restart from the beginning, you can reset the platform.
+
+![](https://github.com/Treeptik/CloudUnit-images/blob/master/warning2.png)
+
+**All your data will be lost!**
+
+In the repository where you have downloaded the `Vagrantfile`, run: `vagrant ssh` to ssh into the box. Finally reset everything:
+```
+$ cd cloudunit/cu-platform && ./reset-all.sh -y
+```
 


### PR DESCRIPTION
Skydns and skydock containers of the platform are replaced by a single container: dnsdock. This one is more often updated and provides exactly the same service. Furthermore, a better tests of dns resolution from the containers is added at each start of the platform.